### PR TITLE
Add release drafter action at organization level

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,14 @@
+branches:
+    - master
+    - main
+name-template: v$NEXT_PATCH_VERSION
+tag-template: v$NEXT_PATCH_VERSION
+categories:
+    - title: 🚀 Improvements
+      label: enhancement
+    - title: 🐛 Bug Fixes
+      label: bug
+change-template: '- #$NUMBER: $TITLE by @$AUTHOR'
+template: |
+    # Changes
+    $CHANGES

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,0 +1,61 @@
+name: Build release
+on:
+  workflow_call
+
+jobs:
+  deploy:
+    name: build dependencies & create artifact
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.0.0
+      - name: Install composer dependencies
+        run: composer install --no-dev -o
+      - name: Clean-up project
+        uses: PrestaShopCorp/github-action-clean-before-deploy@v1.0
+      - name: Prepare auto-index tool
+        run: composer global require prestashop/autoindex
+      - name: Generate index.php
+        run: ~/.composer/vendor/bin/autoindex
+      - name: Create & upload artifact
+        uses: actions/upload-artifact@v1
+        with:
+          name: ${{ github.event.repository.name }}
+          path: ../
+  update_release_draft:
+    runs-on: ubuntu-latest
+    needs: [deploy]
+    if: github.event_name == 'push' && (github.event.ref == 'refs/heads/main' || github.event.ref == 'refs/heads/master')
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v1
+        with:
+          name: ${{ github.event.repository.name }}
+      - id: release_info
+        uses: toolmantim/release-drafter@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Prepare for Release
+        run: |
+          cd ${{ github.event.repository.name }}
+          zip -r ${{ github.event.repository.name }}.zip ${{ github.event.repository.name }}
+      - name: Clean existing assets
+        shell: bash
+        run: |
+          curl -fsSL https://github.com/github/hub/raw/master/script/get | bash -s 2.14.1
+          assets=`bin/hub api -t repos/${{ github.repository }}/releases/${{ steps.release_info.outputs.id }}/assets | awk '/\].url/ { print $2 }'`
+          for asset in $assets
+          do
+              bin/hub api -X DELETE $asset
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Publish to GitHub Release
+        uses: actions/upload-release-asset@v1.0.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.release_info.outputs.upload_url }}
+          asset_path: ./${{ github.event.repository.name }}/${{ github.event.repository.name }}.zip
+          asset_name: ${{ github.event.repository.name }}.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | This PR aims to provide a common github action that every module can use to create a release when changes happen in the `main` or `master` branch. See below the `how to use`.
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | 
| How to test?      | 
| Possible impacts? | 

### How to use

To use it in a module, you can create a new workflow with this:
```yaml
name: Build release
on: [push, pull_request]

jobs:
  build-and-release-draft:
    name: Build & Release draft
    uses: PrestaShop/.github/.github/workflows/build-release.yml@master
```

You can also override the `.github/release-drafter.yml` in your module if you want to change to release-drafter settings, see [the documentation to do so](https://github.com/probot/probot-config#setup).

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
