### PR TITLE
Add path in download-artifact action.

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -31,6 +31,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: ${{ github.event.repository.name }}
+          path: ${{ github.event.repository.name }}
       - id: release_info
         uses: toolmantim/release-drafter@v5
         env:


### PR DESCRIPTION

<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop-project.org/8/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | When switching from download-artifact v1 to download-artifact v3, there is no more extra directory. <br/>This results in failing the "Prepare for Release" and "Publish to GitHub Release" steps.  <br/> See https://github.com/actions/download-artifact/tree/releases/v2#compatibility-between-v1-and-v2
| Type?             | bug fix 
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes [#33749](https://github.com/PrestaShop/PrestaShop/issues/33749)
| Sponsor company   | -
| How to test?      | -
