### PR TITLE
Enhance stale action configuration by adding 'operations-per-run' input for rate limiting

### DIFF
--- a/.github/actions/stale/action.yml
+++ b/.github/actions/stale/action.yml
@@ -10,7 +10,7 @@ inputs:
     required: false
     default: '30'
   exempt-issue-labels:
-    description: 'Comma-separated list of labels to exclude from being marked stale'
+    description: 'Comma-separated list of labels to exclude from being marked stale (the label "Converted to Discussion" is always excluded in addition)'
     required: false
     default: ''
   debug-only:
@@ -38,7 +38,8 @@ runs:
 
         stale-issue-label: 'Stale'
         close-issue-label: 'Stale Action Closed'
-        exempt-issue-labels: ${{ inputs.exempt-issue-labels }}
+        # Always exclude "Converted to Discussion" (GitHub-applied when an issue becomes a discussion)
+        exempt-issue-labels: ${{ inputs.exempt-issue-labels && format('{0},Converted to Discussion', inputs.exempt-issue-labels) || 'Converted to Discussion' }}
 
         remove-stale-when-updated: true
         remove-issue-stale-when-updated: true

--- a/.github/actions/stale/action.yml
+++ b/.github/actions/stale/action.yml
@@ -17,6 +17,10 @@ inputs:
     description: 'If true, log what would be done without making changes'
     required: false
     default: 'false'
+  operations-per-run:
+    description: 'Maximum number of API operations per run (rate limiting)'
+    required: false
+    default: '100'
 runs:
   using: composite
   steps:
@@ -41,7 +45,7 @@ runs:
 
         debug-only: ${{ inputs.debug-only }}
 
-        operations-per-run: 100
+        operations-per-run: ${{ inputs.operations-per-run }}
 
         stale-issue-message: |
           👋 Hi there,


### PR DESCRIPTION



| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Enhance stale action configuration by adding 'operations-per-run' input for rate limiting
| Type?             |  improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | Fixes https://github.com/PrestaShop/PrestaShop/discussions/40567
| Sponsor company   | PrestaShop SA
| How to test?      | Launch workflow "Mark stale issues" with input "operations-per-run parameter" set
