### PR TITLE
Add reusable AI pre-review guard workflow and labels

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -12,3 +12,9 @@
 - name: "QA ✔️ by Community"
   color: '#b8ed50'
   description: "Status: Check done by community member, Code approved"
+- name: "Need AI review"
+  color: '#fbca04'
+  description: "Trigger: Request an AI pre-review from Claude"
+- name: "AI reviewed"
+  color: '#b8ed50'
+  description: "Status: Claude AI has already pre-reviewed this PR"

--- a/.github/workflows/ai-prereview-guard.yml
+++ b/.github/workflows/ai-prereview-guard.yml
@@ -1,0 +1,108 @@
+name: "[Reusable] Pre-review guard (label check + team membership)"
+
+on:
+  workflow_call:
+    inputs:
+      team-slug:
+        required: true
+        type: string
+        description: "Team slug to check against (e.g. prestashop-sa)"
+      actor:
+        required: true
+        type: string
+        description: "GitHub login to verify (github.event.sender.login)"
+      pr-number:
+        required: true
+        type: number
+        description: "PR number"
+      repository:
+        required: true
+        type: string
+        description: "owner/repo (e.g. PrestaShop/ps_apiresources)"
+      reviewed-label:
+        required: false
+        type: string
+        default: "AI reviewed"
+        description: "Label indicating Claude has already reviewed the PR"
+    secrets:
+      org-read-token:
+        required: true
+        description: "PAT with read:org scope"
+      github-token:
+        required: true
+        description: "GITHUB_TOKEN from the calling repository"
+    outputs:
+      can-run:
+        description: "true if actor is a team member AND the PR has not yet been reviewed by Claude"
+        value: ${{ jobs.gate.outputs.can-run }}
+
+jobs:
+  # Step 1: Check label first — cheap call, avoids unnecessary org API usage
+  check-label:
+    runs-on: ubuntu-latest
+    outputs:
+      already-reviewed: ${{ steps.check.outputs.already-reviewed }}
+    steps:
+      - name: Check for reviewed label
+        id: check
+        env:
+          GH_TOKEN: ${{ secrets.github-token }}
+          PR_NUMBER: ${{ inputs.pr-number }}
+          REPO: ${{ inputs.repository }}
+          LABEL: ${{ inputs.reviewed-label }}
+        run: |
+          HAS=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json labels \
+            | jq -r --arg l "$LABEL" '[.labels[].name] | contains([$l])')
+          echo "already-reviewed=$HAS" >> "$GITHUB_OUTPUT"
+          if [ "$HAS" = "true" ]; then
+            echo "⚠️ PR #$PR_NUMBER already has the '$LABEL' label — skipping Claude review." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  # Step 2: Check team membership only if label is absent
+  check-membership:
+    runs-on: ubuntu-latest
+    needs: check-label
+    if: needs.check-label.outputs.already-reviewed != 'true'
+    outputs:
+      is-member: ${{ steps.check.outputs.is-member }}
+    steps:
+      - name: Check team membership
+        id: check
+        env:
+          TOKEN: ${{ secrets.org-read-token }}
+          ACTOR: ${{ inputs.actor }}
+          TEAM: ${{ inputs.team-slug }}
+        run: |
+          STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
+            -H "Authorization: Bearer $TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/orgs/PrestaShop/teams/$TEAM/memberships/$ACTOR")
+          if [ "$STATUS" = "200" ]; then
+            echo "is-member=true" >> "$GITHUB_OUTPUT"
+            echo "✅ $ACTOR is a member of $TEAM — Claude review will run." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "is-member=false" >> "$GITHUB_OUTPUT"
+            echo "⛔ $ACTOR is not a member of $TEAM — skipping Claude review." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+  # Step 3: Evaluate combined result
+  gate:
+    runs-on: ubuntu-latest
+    needs: [check-label, check-membership]
+    if: always()
+    outputs:
+      can-run: ${{ steps.evaluate.outputs.can-run }}
+    steps:
+      - name: Evaluate guard conditions
+        id: evaluate
+        env:
+          IS_MEMBER: ${{ needs.check-membership.outputs.is-member }}
+          ALREADY_REVIEWED: ${{ needs.check-label.outputs.already-reviewed }}
+        run: |
+          if [ "$IS_MEMBER" = "true" ] && [ "$ALREADY_REVIEWED" != "true" ]; then
+            echo "can-run=true" >> "$GITHUB_OUTPUT"
+            echo "✅ All guards passed — Claude pre-review can run." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "can-run=false" >> "$GITHUB_OUTPUT"
+            echo "🚫 Guard blocked: is-member=$IS_MEMBER, already-reviewed=$ALREADY_REVIEWED." >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | master
| Description?      | Add a reusable workflow `ai-prereview-guard.yml` that checks team membership and duplicate review label before allowing a Claude AI pre-review to run. Also add `Need AI review` and `AI reviewed` labels to the org-wide `labels.yml`.
| Type?             | new feature
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Merge this PR and the companion PR on `ps_apiresources` 2. On a test PR in `ps_apiresources`, add the `Need AI review` label as a PrestaShop SA team member 3. Verify the guard workflow runs: label check passes, membership check passes, `can-run` output is `true` 4. Add the label again after `AI reviewed` is present — verify the workflow skips with a warning 5. Have a non-SA-member add the label — verify the workflow skips
| UI Tests          |
| Fixed issue or discussion? | Fixes PrestaShop/PrestaShop#41245
| Related PRs       | Companion PR on ps_apiresources: PrestaShop/ps_apiresources#192
| Sponsor company   | PrestaShop SA

## Details

### Reusable guard workflow (`ai-prereview-guard.yml`)

Accepts `team-slug`, `actor`, `pr-number`, `repository`, and `reviewed-label` inputs. Runs two sequential checks:

1. **Label check (first)** — checks if the `AI reviewed` label is already on the PR. If present, skips early to save an org API call.
2. **Team membership check** — only runs if label is absent. Verifies the actor is a member of the specified GitHub team via the org API.

Outputs a single `can-run` boolean for the caller workflow.

### Org-wide labels

Added to `labels.yml` for sync across all PrestaShop repositories:
- `Need AI review` (#7B61FF) — opt-in trigger
- `AI reviewed` (#7B61FF) — marks that Claude has already reviewed