### PR TITLE
Add job display names and upgrade actions/checkout to v6

### DIFF
--- a/.github/workflows/ai-guarded-review.yml
+++ b/.github/workflows/ai-guarded-review.yml
@@ -62,6 +62,7 @@ on:
 jobs:
   # Step 1: Check if PR was already reviewed
   check-label:
+    name: Check reviewed label
     runs-on: ubuntu-latest
     outputs:
       already-reviewed: ${{ steps.check.outputs.already-reviewed }}
@@ -83,6 +84,7 @@ jobs:
 
   # Step 2: Check team membership only if label is absent
   check-membership:
+    name: Check team membership
     runs-on: ubuntu-latest
     needs: check-label
     if: needs.check-label.outputs.already-reviewed != 'true'
@@ -132,6 +134,7 @@ jobs:
 
   # Step 3: Evaluate guard
   gate:
+    name: Evaluate guard
     runs-on: ubuntu-latest
     needs: [check-label, check-membership]
     if: always()
@@ -154,6 +157,7 @@ jobs:
 
   # Step 4: Guard failed — remove trigger label and fail
   guard-failed:
+    name: Guard failed
     needs: gate
     if: needs.gate.outputs.can-run != 'true'
     runs-on: ubuntu-latest
@@ -170,6 +174,7 @@ jobs:
 
   # Step 5: Run Claude review
   ai-review:
+    name: Claude AI review
     needs: gate
     if: needs.gate.outputs.can-run == 'true'
     runs-on: ubuntu-latest
@@ -180,7 +185,7 @@ jobs:
       GH_TOKEN: ${{ secrets.github-token }}
       PR_NUMBER: ${{ inputs.pr-number }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
| Questions         | Answers
| ----------------- | -------------------------------------------------------
| Branch?           | master
| Description?      | Add human-readable `name:` to all jobs in `ai-guarded-review.yml` and upgrade `actions/checkout` from v4 to v6 to fix Node.js 20 deprecation warning
| Type?             | improvement
| Category?         | CO
| BC breaks?        | no
| Deprecations?     | no
| How to test?      | 1. Merge this PR and the companion PR on `ps_apiresources` 2. Trigger a review and verify job names display as readable labels (e.g. "Check reviewed label", "Claude AI review") instead of kebab-case keys 3. Verify no Node.js 20 deprecation warning
| UI Tests          |
| Fixed issue or discussion? | Related to PrestaShop/PrestaShop#41245
| Related PRs       | Companion PR on ps_apiresources
| Sponsor company   | PrestaShop SA

## Details

- Added `name:` to all jobs: "Check reviewed label", "Check team membership", "Evaluate guard", "Guard failed", "Claude AI review"
- Upgraded `actions/checkout` from v4 to v6 (Node.js 20 → Node.js 24)