### PR TITLE
Add fallback repository support to the generate-changelog action

### DIFF
--- a/.github/actions/generate-changelog/action.yml
+++ b/.github/actions/generate-changelog/action.yml
@@ -20,6 +20,10 @@ inputs:
     description: 'GitHub repository (owner/repo). Defaults to the current repository.'
     required: false
     default: ${{ github.repository }}
+  fallback_repository:
+    description: 'Fallback repository (owner/repo) used to resolve PRs not found in `repository`, e.g. when running on a private mirror whose history references upstream PRs. When set, `repository` is considered private and its address is never used in generated URLs. Empty or equal to `repository` = disabled.'
+    required: false
+    default: ''
   github_token:
     description: 'GitHub token for API access'
     required: true
@@ -54,4 +58,5 @@ runs:
         NEXT_VERSION: ${{ inputs.next_version }}
         RELEASE_DATE: ${{ inputs.release_date }}
         GH_REPOSITORY: ${{ inputs.repository }}
+        FALLBACK_REPOSITORY: ${{ inputs.fallback_repository }}
       run: bash ${{ github.action_path }}/../../scripts/generate-changelog.sh

--- a/.github/scripts/generate-changelog.sh
+++ b/.github/scripts/generate-changelog.sh
@@ -11,12 +11,18 @@ set -euo pipefail
 #   NEXT_VERSION      - New version string (e.g. 9.1.0 Beta 1)
 #   RELEASE_DATE      - Date for the new release (YYYY-MM-DD), default: today
 #   GH_REPOSITORY     - owner/repo
+#   FALLBACK_REPOSITORY - optional owner/repo used to resolve PRs not found in GH_REPOSITORY
+#                         (e.g. when GH_REPOSITORY is a private mirror whose history references
+#                         PRs merged in the upstream repository)
 
 PREVIOUS_REF="${PREVIOUS_REF:?PREVIOUS_REF is required}"
 TARGET_REF="${TARGET_REF:-HEAD}"
 NEXT_VERSION="${NEXT_VERSION:?NEXT_VERSION is required}"
 RELEASE_DATE="${RELEASE_DATE:-$(date +%Y-%m-%d)}"
 REPO="${GH_REPOSITORY:?GH_REPOSITORY is required}"
+FALLBACK_REPO="${FALLBACK_REPOSITORY:-}"
+# No fallback needed when it points to the repository itself
+[[ "$FALLBACK_REPO" == "$REPO" ]] && FALLBACK_REPO=""
 
 # -----------------------------------------------------------------------------
 # Map Category code (template) -> Changelog section name
@@ -91,14 +97,25 @@ if [[ -z "$PR_NUMBERS" ]]; then
   PRS_JSON="[]"
   PR_COUNT=0
 else
-  # Build PRS_JSON array by fetching title+author for each PR from the API
+  # Build PRS_JSON array by fetching title+author for each PR from the API.
+  # PRs are searched in REPO first, then in FALLBACK_REPO (if configured); each entry
+  # keeps track of the repository it was resolved in (used for API calls and URLs).
   PRS_JSON="[]"
   for number in $PR_NUMBERS; do
-    pr_info=$(gh pr view "$number" --repo "$REPO" --json number,title,author -q '.' 2>/dev/null || echo '')
+    pr_repo="$REPO"
+    pr_info=$(gh pr view "$number" --repo "$pr_repo" --json number,title,author -q '.' 2>/dev/null || echo '')
+    if [[ -z "$pr_info" && -n "$FALLBACK_REPO" ]]; then
+      pr_repo="$FALLBACK_REPO"
+      pr_info=$(gh pr view "$number" --repo "$pr_repo" --json number,title,author -q '.' 2>/dev/null || echo '')
+    fi
     if [[ -n "$pr_info" ]]; then
-      PRS_JSON=$(echo "$PRS_JSON" | jq --argjson pr "$pr_info" '. + [$pr]')
+      PRS_JSON=$(echo "$PRS_JSON" | jq --argjson pr "$pr_info" --arg repo "$pr_repo" '. + [$pr + {repo: $repo}]')
     else
-      echo "::error::Could not fetch PR #${number}." >&2
+      if [[ -n "$FALLBACK_REPO" ]]; then
+        echo "::error::Could not fetch PR #${number} (searched in ${REPO} and ${FALLBACK_REPO})." >&2
+      else
+        echo "::error::Could not fetch PR #${number}." >&2
+      fi
       exit 1
     fi
   done
@@ -126,7 +143,8 @@ while read -r pr; do
 
   title=$(echo "$pr" | jq -r '.title | gsub("\n"; " ")')
   author=$(echo "$pr" | jq -r '.author.login')
-  pr_data=$(gh pr view "$number" --repo "$REPO" --json body,milestone -q '.' 2>/dev/null || echo '{}')
+  pr_repo=$(echo "$pr" | jq -r '.repo')
+  pr_data=$(gh pr view "$number" --repo "$pr_repo" --json body,milestone -q '.' 2>/dev/null || echo '{}')
   body=$(echo "$pr_data" | jq -r '.body // ""')
   milestone=$(echo "$pr_data" | jq -r '.milestone.title // ""')
 
@@ -145,14 +163,20 @@ while read -r pr; do
   [[ -z "$milestone" || "$milestone" == "null" ]] && reasons+=("Milestone is empty")
 
   if [[ ${#reasons[@]} -gt 0 ]]; then
-    echo "#${number}" >> "$ERRORS_FILE"
+    echo "#${number}|${pr_repo}" >> "$ERRORS_FILE"
     echo "$title" >> "$ERRORS_FILE"
     for r in "${reasons[@]}"; do echo "$r" >> "$ERRORS_FILE"; done
     echo "---" >> "$ERRORS_FILE"
   fi
 
   line="    - #${number}: ${title} (by @${author})"
-  formatted_line="    - [#${number}](https://github.com/${REPO}/pull/${number}): ${title} (by [@${author}](https://github.com/${author}))"
+  # When a fallback repository is configured, REPO is a private mirror: its address must
+  # never appear in the generated changelog, so PRs resolved in it are not linked.
+  if [[ -n "$FALLBACK_REPO" && "$pr_repo" == "$REPO" ]]; then
+    formatted_line="    - #${number}: ${title} (by [@${author}](https://github.com/${author}))"
+  else
+    formatted_line="    - [#${number}](https://github.com/${pr_repo}/pull/${number}): ${title} (by [@${author}](https://github.com/${author}))"
+  fi
   echo "${category_name}|${type_name}|${line}" >> "$CATEGORIZED_FILE"
   echo "${category_name}|${type_name}|${formatted_line}" >> "$CATEGORIZED_FORMATTED_FILE"
 done < <(echo "$PRS_JSON" | jq -c 'sort_by(-.number) | .[]')
@@ -168,9 +192,11 @@ if [[ -s "$ERRORS_FILE" ]]; then
   echo "PRs in error:" >&2
   while IFS= read -r err_line; do
     if [[ "$err_line" == \#* ]]; then
-      num="${err_line#\#}"
+      num_and_repo="${err_line#\#}"
+      num="${num_and_repo%%|*}"
+      err_repo="${num_and_repo##*|}"
       read -r tit || true
-      echo "::error:: #${num}: ${tit}  (https://github.com/${REPO}/pull/${num})" >&2
+      echo "::error:: #${num}: ${tit}  (https://github.com/${err_repo}/pull/${num})" >&2
       while IFS= read -r reason_line; do
         [[ "$reason_line" == "---" ]] && break
         echo "  • $reason_line" >&2
@@ -379,10 +405,10 @@ FIRST_TIME_CONTRIBUTORS_PAIRS=$(echo "$FIRST_TIME_CONTRIBUTORS_PAIRS" | sed '/^$
 CONTRIBUTORS_CSV=$(echo "$NEW_CONTRIBUTORS_PAIRS" | paste -sd ',' - | sed 's/,/, /g')
 NEW_CONTRIBUTORS_CSV=$(echo "$FIRST_TIME_CONTRIBUTORS_PAIRS" | paste -sd ',' - | sed 's/,/, /g')
 
-CONTRIBUTORS_GRID_INNER=$(echo "$NEW_CONTRIBUTOR_LOGINS" | sed '/^$/d' | sed 's/.*/"&"/' | paste -sd ' ')
+CONTRIBUTORS_GRID_INNER=$(echo "$NEW_CONTRIBUTOR_LOGINS" | sed '/^$/d' | sed 's/.*/"&"/' | paste -sd ' ' -)
 CONTRIBUTORS_GRID="{{< contributors-grid ${CONTRIBUTORS_GRID_INNER} / >}}"
 
-NEW_CONTRIBUTORS_GRID_INNER=$(echo "$FIRST_TIME_LOGINS" | sed '/^$/d' | sed 's/.*/"&"/' | paste -sd ' ')
+NEW_CONTRIBUTORS_GRID_INNER=$(echo "$FIRST_TIME_LOGINS" | sed '/^$/d' | sed 's/.*/"&"/' | paste -sd ' ' -)
 NEW_CONTRIBUTORS_GRID="{{< contributors-grid ${NEW_CONTRIBUTORS_GRID_INNER} / >}}"
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
| Questions         | Answers
| ------------------| -------------------------------------------------------
| Description?      | Add an optional `fallback_repository` input to the `generate-changelog` action. When the changelog is generated on a private mirror repository, the merge commits synced from the upstream repository reference PR numbers that do not exist in the mirror, so the script failed with `Could not fetch PR #...`. PRs are now resolved in `repository` first, then in `fallback_repository` when configured. When a fallback is set, `repository` is considered private: its address is never used in the generated URLs, so PRs resolved in it are listed without a link in the formatted changelog. Also fixes two `paste` invocations that were missing the stdin operand (BSD/macOS compatibility, the script is documented as working on both Linux and macOS).
| Type?             | improvement
| BC breaks?        | no
| Deprecations?     | no
| Fixed ticket?     | N/A
| Sponsor company   | N/A
| How to test?      | Run `.github/scripts/generate-changelog.sh` with `GH_REPOSITORY` pointing to a repository whose history contains merge commits referencing PRs from another repository (e.g. a mirror), and `FALLBACK_REPOSITORY` pointing to that upstream repository: all PRs are resolved and the generated changelog/outputs never contain the mirror repository address. Without `FALLBACK_REPOSITORY` (or when it equals `GH_REPOSITORY`), behavior is unchanged.

## Details

- PR lookup: `repository` first, then `fallback_repository`; each PR keeps track of the repository it was resolved in, which is used for the follow-up API calls (body, milestone) and for error report URLs.
- Formatted changelog (`changelog_formatted` output): PRs resolved in the fallback repository are linked to it; PRs resolved in the main repository are not linked when a fallback is configured (private mirror use case), e.g. `- #123: Title (by [@author](https://github.com/author))`.
- The error message on an unresolvable PR now lists both repositories that were searched.
- Tested end to end on a real 99-PR release range on a private mirror (2 mirror PRs + 97 upstream PRs): all PRs resolved, `0` occurrences of the mirror address in `docs/CHANGELOG.txt`, `CONTRIBUTORS.md` and all action outputs.
